### PR TITLE
feat: intrinsic facade for `crypto`

### DIFF
--- a/elide/runtime/js/intrinsics/crypto/crypto.ts
+++ b/elide/runtime/js/intrinsics/crypto/crypto.ts
@@ -1,0 +1,19 @@
+import {globalContext, installGlobal} from "../base";
+import type {Crypto} from "../primordials";
+
+/**
+ * @return Crypto Intrinsic `Crypto` bridge.
+ */
+function resolveIntrinsic(): Crypto {
+    return globalContext['__elide_crypto'] as Crypto;
+}
+
+declare global {
+    /**
+     * Top-level Web Crypto API interface.
+     */
+        // @ts-ignore
+    export const crypto: Crypto;
+}
+
+installGlobal('crypto', resolveIntrinsic());

--- a/elide/runtime/js/intrinsics/primordials.ts
+++ b/elide/runtime/js/intrinsics/primordials.ts
@@ -24,6 +24,64 @@ export interface Base64 {
 }
 
 /**
+ * ## API: RandomSource
+ *
+ * Defines the API surface of a random source, which is used to generate random bytes and UUIDs in a secure manner.
+ * This interface is a subset of the Web Crypto API `RandomSource` interface.
+ */
+export interface RandomSource {
+    /**
+     * TBD.
+     */
+    getRandomValues<T extends ArrayBufferView>(array: T): T;
+
+    /**
+     * TBD.
+     */
+    getRandomValues(array: Uint8Array): Uint8Array;
+
+    /**
+     * TBD.
+     */
+    getRandomValues(array: Uint16Array): Uint16Array;
+
+    /**
+     * TBD.
+     */
+    getRandomValues(array: Uint32Array): Uint32Array;
+
+    /**
+     * TBD.
+     */
+    getRandomValues(array: Int8Array): Int8Array;
+
+    /**
+     * TBD.
+     */
+    getRandomValues(array: Int16Array): Int16Array;
+
+    /**
+     * TBD.
+     */
+    getRandomValues(array: Int32Array): Int32Array;
+
+    /**
+     * TBD.
+     */
+    randomUuid(): string;
+}
+
+/**
+ * ## API: Crypto
+ *
+ * Top-level API interface for the Web Crypto API. Includes methods for generating raw bytes, and obtaining random UUIDs
+ * generated in a secure manner.
+ */
+export interface Crypto extends RandomSource {
+
+}
+
+/**
  * # API: Console
  *
  * Defines the surface of the Console API for Elide. Elide's console intrinsics are standards-compliant with the WhatWG

--- a/elide/runtime/js/modules/fs/index.ts
+++ b/elide/runtime/js/modules/fs/index.ts
@@ -1,5 +1,4 @@
 
 import fs from "./fs";
 
-export * from "./fs";
 export default fs;


### PR DESCRIPTION
## Summary

Adds facade-side code for new Web Crypto API support. Part of elide-dev/elide#320.

## Changelog

- feat: resolve and mount `crypto` intrinsic
- chore: add initial interface for types
