### PR TITLE
fix(nodejs): migrate to deferred fs intrinsic bindings

### DIFF
--- a/elide/runtime/js/modules/fs/fs.ts
+++ b/elide/runtime/js/modules/fs/fs.ts
@@ -17,7 +17,7 @@
  * Provides a shim which offers a `fs` module implementation that is compatible with Node.js-style imports.
  */
 
-const internals: any = globalThis['__Elide_node_fs__'];
+const internals: any = globalThis['__Elide_node_fs__']();
 
 /**
  * File system constants

--- a/elide/runtime/js/modules/fs/promises/fs-async.ts
+++ b/elide/runtime/js/modules/fs/promises/fs-async.ts
@@ -17,7 +17,7 @@
  * Provides a shim which offers a `fs/promises` module implementation that is compatible with Node.js-style imports.
  */
 
-const internals: any = globalThis['__Elide_node_fs_promises__'];
+const internals: any = globalThis['__Elide_node_fs_promises__']();
 
 /**
  * File system constants


### PR DESCRIPTION
Uses executable `fs` bindings to support deferred values. This is required by [elide/969](https://github.com/elide-dev/elide/pull/969), as the Node.js `fs` builtin does not have access to the actual VFS instance until after the bindings are installed.