### PR TITLE
feat: support nodejs buffer module

### DIFF
--- a/elide/runtime/js/modules/buffer/buffer.ts
+++ b/elide/runtime/js/modules/buffer/buffer.ts
@@ -17,6 +17,8 @@
  * Provides a shim which offers a `Buffer` implementation that is compatible with Node.js-style imports.
  */
 
+const module = globalThis['__Elide_node_buffer__module'];
+
 /**
  * Maximum buffer size.
  */
@@ -48,12 +50,12 @@ export const SlowBuffer = Buffer;
 /**
  * Export the intrinsic `Blob` type.
  */
-export const Blob = globalThis['Blob'];
+export const Blob = globalThis['__Elide_node_buffer__Blob'];
 
 /**
  * Export the intrinsic `File` type.
  */
-export const File = globalThis['File'];
+export const File = globalThis['__Elide_node_buffer__File'];
 
 /**
  * Resolves a 'blob:nodedata:...' to an associated <Blob> object registered using a prior call to
@@ -92,7 +94,7 @@ export function resolveObjectURL(blob: Blob): string {
  * @returns The transcoded buffer.
  */
 export function transcode(buffer: Buffer | Uint8Array, fromEnc: string, toEnc: string): Buffer {
-  throw new Error('Not implemented'); 
+  return module.transcode(buffer, fromEnc, toEnc)
 }
 
 /**
@@ -102,7 +104,7 @@ export function transcode(buffer: Buffer | Uint8Array, fromEnc: string, toEnc: s
  * @returns `true` if the buffer is valid UTF-8, otherwise `false`.
  */
 export function isUtf8(buffer: Buffer | Uint8Array): boolean {
-  throw new Error('Not implemented');
+  return module.isUtf8(buffer)
 }
 
 /**
@@ -112,7 +114,7 @@ export function isUtf8(buffer: Buffer | Uint8Array): boolean {
  * @returns `true` if the buffer is valid ASCII, otherwise `false`.
  */
 export function isAscii(buffer: Buffer | Uint8Array): boolean {
-  throw new Error('Not implemented');
+  return module.isAscii(buffer)
 }
 
 /**
@@ -126,7 +128,7 @@ export function isAscii(buffer: Buffer | Uint8Array): boolean {
  * For code running using Node.js APIs, converting between base64-encoded strings and binary data should be performed
  * using Buffer.from(str, 'base64') and buf.toString('base64').
  */
-export const btoa = globalThis['btoa'];
+export const btoa = module.btoa;
 
 /**
  * Decodes a string of Base64-encoded data into bytes, and encodes those bytes into a string using Latin-1 (ISO-8859-1).
@@ -138,7 +140,7 @@ export const btoa = globalThis['btoa'];
  * code running using Node.js APIs, converting between base64-encoded strings and binary data should be performed
  * using Buffer.from(str, 'base64') and buf.toString('base64').
  */
-export const atob = globalThis['atob'];
+export const atob = module.atob;
 
 // `Buffer` is assigned as the default export.
 export default Buffer;


### PR DESCRIPTION
This PR adds support for [elide/1026](https://github.com/elide-dev/elide/pull/1026), using the bindings for the Node.js built-in `buffer`.